### PR TITLE
Use bash instead of sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Check out the [Quick Start](#quick-start) guide for how-to-use examples.
 
 ### From Script
 ```bash
-curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh | bash
 ```
 
 ### From Cargo


### PR DESCRIPTION
In install.sh, the first line is #/bin/bash. There is bash syntax in the script. Executing with sh will result in an error