### PR TITLE
Skip test mvr when the target OS is windows

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -187,6 +187,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_workflow() -> Result<()> {
+        if cfg!(windows) {
+            eprintln!("Skipped: mvr is not supported on Windows");
+            return Ok(());
+        }
+
         let test_env = TestEnv::new()?;
         test_env.initialize_paths()?;
 
@@ -273,6 +278,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_default_mvr_workflow() -> Result<(), anyhow::Error> {
+        if cfg!(windows) {
+            eprintln!("Skipped: mvr is not supported on Windows");
+            return Ok(());
+        }
+
         let test_env = TestEnv::new()?;
         test_env.initialize_paths()?;
 


### PR DESCRIPTION
Temporarily skipping MVR tests on Windows as there is currently no Windows-compatible package available. This ensures CI pipelines pass while we work on Windows support.