### PR TITLE
feat: table-style output for list, show, and default get commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +272,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -897,6 +930,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1548,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "clap_complete",
+ "comfy-table",
  "console",
  "dirs",
  "env_logger",
@@ -1517,6 +1557,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "log",
+ "md5",
  "mockall",
  "predicates",
  "regex",
@@ -1778,6 +1819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2041,28 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ indicatif = "0.17"
 lazy_static = "1.5.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.19", default-features = false, features = ["blocking", "json", "stream", "rustls-tls"] }
+prettytable = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 tar = "0.4.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ lazy_static = "1.5.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.19", default-features = false, features = ["blocking", "json", "stream", "rustls-tls"] }
 md5 = "0.7"
-prettytable = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 tar = "0.4.44"
@@ -27,6 +26,7 @@ tempfile = "3.20"
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = { version = "0.1.41", features = ["log"] }
 whoami = "1.5.2"
+comfy-table = "7.1.4"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ indicatif = "0.17"
 lazy_static = "1.5.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.19", default-features = false, features = ["blocking", "json", "stream", "rustls-tls"] }
+md5 = "0.7"
 prettytable = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"

--- a/src/commands/default/get.rs
+++ b/src/commands/default/get.rs
@@ -10,6 +10,7 @@ use crate::{
     paths::default_file_path,
     types::{Binaries, Version},
 };
+use prettytable::{Table, row};
 
 /// Get the default Sui CLI version.
 #[derive(Args, Debug)]
@@ -17,12 +18,22 @@ pub struct Command;
 
 impl Command {
     pub fn exec(&self) -> Result<()> {
-        // let default_binaries = DefaultBinaries::load()?;
         let default = std::fs::read_to_string(default_file_path()?)?;
         let default: BTreeMap<String, (String, Version, bool)> = serde_json::from_str(&default)?;
         let binaries = Binaries::from(default);
 
-        println!("\x1b[1mDefault binaries:\x1b[0m\n{binaries}");
+        let mut table = Table::new();
+        table.add_row(row!["Network", "Binary", "Version", "Debug"]);
+        for b in &binaries.binaries {
+            table.add_row(row![
+                b.network_release,
+                b.binary_name,
+                b.version,
+                if b.debug { "Yes" } else { "No" }
+            ]);
+        }
+        println!("\x1b[1mDefault binaries:\x1b[0m");
+        table.printstd();
         Ok(())
     }
 }

--- a/src/commands/default/get.rs
+++ b/src/commands/default/get.rs
@@ -10,7 +10,8 @@ use crate::{
     paths::default_file_path,
     types::{Binaries, Version},
 };
-use prettytable::{Table, row};
+
+use crate::commands::print_table;
 
 /// Get the default Sui CLI version.
 #[derive(Args, Debug)]
@@ -22,18 +23,8 @@ impl Command {
         let default: BTreeMap<String, (String, Version, bool)> = serde_json::from_str(&default)?;
         let binaries = Binaries::from(default);
 
-        let mut table = Table::new();
-        table.add_row(row!["Network", "Binary", "Version", "Debug"]);
-        for b in &binaries.binaries {
-            table.add_row(row![
-                b.network_release,
-                b.binary_name,
-                b.version,
-                if b.debug { "Yes" } else { "No" }
-            ]);
-        }
         println!("\x1b[1mDefault binaries:\x1b[0m");
-        table.printstd();
+        print_table(&binaries.binaries);
         Ok(())
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,7 +15,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use comfy_table::presets::ASCII_BORDERS_ONLY;
 use comfy_table::Table;
 use crate::types::BinaryVersion;
-
+pub const TABLE_FORMAT: &str = "  ── ══      ──    ";
 #[derive(Parser)]
 #[command(arg_required_else_help = true, disable_help_subcommand = true)]
 #[command(version, about)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,9 @@ mod which;
 
 use anyhow::{anyhow, bail, Result};
 use clap::{Parser, Subcommand, ValueEnum};
+use comfy_table::presets::ASCII_BORDERS_ONLY;
+use comfy_table::Table;
+use crate::types::BinaryVersion;
 
 #[derive(Parser)]
 #[command(arg_required_else_help = true, disable_help_subcommand = true)]
@@ -210,6 +213,34 @@ pub fn parse_version_spec(spec: Option<String>) -> Result<(String, Option<String
             }
         }
     }
+}
+
+pub fn print_table(binaries: &Vec<BinaryVersion>) {
+    let mut binaries_vec = binaries.clone();
+    // sort by Binary column
+    binaries_vec.sort_by_key(|b| b.binary_name.clone());
+    let mut table = Table::new();
+    table
+        .load_preset(ASCII_BORDERS_ONLY)
+        .set_header(vec!["Binary", "Release", "Version", "Debug"])
+        .add_rows(
+            binaries_vec
+                .into_iter()
+                .map(|binary| {
+                    vec![
+                        binary.binary_name,
+                        binary.network_release,
+                        binary.version,
+                        if binary.debug {
+                            "Yes".to_string()
+                        } else {
+                            "No".to_string()
+                        },
+                    ]
+                })
+                .collect::<Vec<Vec<String>>>(),
+        );
+    println!("{table}");
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -221,7 +221,7 @@ pub fn print_table(binaries: &Vec<BinaryVersion>) {
     let mut table = Table::new();
     table
         .load_preset(TABLE_FORMAT)
-        .set_header(vec!["Binary", "Release", "Version", "Debug"])
+        .set_header(vec!["Binary", "Release/Branch", "Version", "Debug"])
         .add_rows(
             binaries_vec
                 .into_iter()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -220,7 +220,7 @@ pub fn print_table(binaries: &Vec<BinaryVersion>) {
     binaries_vec.sort_by_key(|b| b.binary_name.clone());
     let mut table = Table::new();
     table
-        .load_preset(ASCII_BORDERS_ONLY)
+        .load_preset(TABLE_FORMAT)
         .set_header(vec!["Binary", "Release", "Version", "Debug"])
         .add_rows(
             binaries_vec

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,7 +12,6 @@ mod which;
 
 use anyhow::{anyhow, bail, Result};
 use clap::{Parser, Subcommand, ValueEnum};
-use comfy_table::presets::ASCII_BORDERS_ONLY;
 use comfy_table::Table;
 use crate::types::BinaryVersion;
 pub const TABLE_FORMAT: &str = "  ── ══      ──    ";

--- a/src/component/list.rs
+++ b/src/component/list.rs
@@ -2,16 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use prettytable::{Table, row};
+use comfy_table::presets::ASCII_BORDERS_ONLY;
+use comfy_table::*;
 
 /// List all available components
 pub async fn list_components() -> Result<()> {
     let components = crate::handlers::available_components();
     let mut table = Table::new();
-    table.add_row(row!["Available Binaries"]);
-    for component in components {
-        table.add_row(row![component]);
-    }
-    table.printstd();
+    table.load_preset(ASCII_BORDERS_ONLY)
+        .set_header(vec![Cell::new("Available Components")])
+        .add_rows(
+            components.iter().map(|component| {
+                vec![Cell::new(component)]
+            }).collect::<Vec<Vec<Cell>>>(),
+        );
+    println!("{table}");
     Ok(())
 }

--- a/src/component/list.rs
+++ b/src/component/list.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use prettytable::{Table, row};
 
 /// List all available components
 pub async fn list_components() -> Result<()> {
     let components = crate::handlers::available_components();
-    println!("Available binaries to install:");
+    let mut table = Table::new();
+    table.add_row(row!["Available Binaries"]);
     for component in components {
-        println!(" - {}", component);
+        table.add_row(row![component]);
     }
+    table.printstd();
     Ok(())
 }

--- a/src/component/list.rs
+++ b/src/component/list.rs
@@ -9,7 +9,7 @@ use comfy_table::*;
 pub async fn list_components() -> Result<()> {
     let components = crate::handlers::available_components();
     let mut table = Table::new();
-    table.load_preset(ASCII_BORDERS_ONLY)
+    table.load_preset(TABLE_FORMAT)
         .set_header(vec![Cell::new("Available Components")])
         .add_rows(
             components.iter().map(|component| {

--- a/src/component/list.rs
+++ b/src/component/list.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::commands::TABLE_FORMAT;
 use anyhow::Result;
-use comfy_table::presets::ASCII_BORDERS_ONLY;
 use comfy_table::*;
 
 /// List all available components

--- a/src/component/list.rs
+++ b/src/component/list.rs
@@ -10,7 +10,7 @@ pub async fn list_components() -> Result<()> {
     let components = crate::handlers::available_components();
     let mut table = Table::new();
     table.load_preset(TABLE_FORMAT)
-        .set_header(vec![Cell::new("Available Components")])
+        .set_header(vec![Cell::new("Available Binaries to Install")])
         .add_rows(
             components.iter().map(|component| {
                 vec![Cell::new(component)]

--- a/src/handlers/show.rs
+++ b/src/handlers/show.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use anyhow::Error;
 use std::collections::BTreeMap;
+use prettytable::{Table, row};
 
 /// Handles the `show` command
 pub fn handle_show() -> Result<(), Error> {
@@ -15,18 +16,36 @@ pub fn handle_show() -> Result<(), Error> {
     let default: BTreeMap<String, (String, Version, bool)> = serde_json::from_str(&default)?;
     let default_binaries = Binaries::from(default);
 
-    println!("\x1b[1mDefault binaries:\x1b[0m\n{default_binaries}");
+    // Default binaries table
+    let mut default_table = Table::new();
+    default_table.add_row(row!["Network", "Binary", "Version", "Debug"]);
+    for b in &default_binaries.binaries {
+        default_table.add_row(row![
+            b.network_release,
+            b.binary_name,
+            b.version,
+            if b.debug { "Yes" } else { "No" }
+        ]);
+    }
+    println!("\x1b[1mDefault binaries:\x1b[0m");
+    default_table.printstd();
 
+    // Installed binaries table
     let installed_binaries = installed_binaries_grouped_by_network(None)?;
-
-    println!("\x1b[1mInstalled binaries:\x1b[0m");
-
+    let mut installed_table = Table::new();
+    installed_table.add_row(row!["Network", "Binary", "Version", "Debug"]);
     for (network, binaries) in installed_binaries {
-        println!("[{network} release/branch]");
-        for binary in binaries {
-            println!("    {binary}");
+        for b in binaries {
+            installed_table.add_row(row![
+                network.to_string(),
+                b.binary_name,
+                b.version,
+                if b.debug { "Yes" } else { "No" }
+            ]);
         }
     }
+    println!("\x1b[1mInstalled binaries:\x1b[0m");
+    installed_table.printstd();
 
     Ok(())
 }

--- a/src/handlers/show.rs
+++ b/src/handlers/show.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use anyhow::Error;
 use std::collections::BTreeMap;
-use prettytable::{Table, row};
+
+use crate::commands::print_table;
 
 /// Handles the `show` command
 pub fn handle_show() -> Result<(), Error> {
@@ -17,35 +18,17 @@ pub fn handle_show() -> Result<(), Error> {
     let default_binaries = Binaries::from(default);
 
     // Default binaries table
-    let mut default_table = Table::new();
-    default_table.add_row(row!["Network", "Binary", "Version", "Debug"]);
-    for b in &default_binaries.binaries {
-        default_table.add_row(row![
-            b.network_release,
-            b.binary_name,
-            b.version,
-            if b.debug { "Yes" } else { "No" }
-        ]);
-    }
+
     println!("\x1b[1mDefault binaries:\x1b[0m");
-    default_table.printstd();
+    print_table(&default_binaries.binaries);
 
     // Installed binaries table
     let installed_binaries = installed_binaries_grouped_by_network(None)?;
-    let mut installed_table = Table::new();
-    installed_table.add_row(row!["Network", "Binary", "Version", "Debug"]);
-    for (network, binaries) in installed_binaries {
-        for b in binaries {
-            installed_table.add_row(row![
-                network.to_string(),
-                b.binary_name,
-                b.version,
-                if b.debug { "Yes" } else { "No" }
-            ]);
-        }
-    }
+    let binaries = installed_binaries.into_iter().flat_map(|(_,binaries)| {
+        binaries.to_owned()
+    }).collect();
     println!("\x1b[1mInstalled binaries:\x1b[0m");
-    installed_table.printstd();
+    print_table(&binaries);
 
     Ok(())
 }


### PR DESCRIPTION
- Use prettytable to display available components, default binaries, and installed binaries in a clear table format.
- Improves readability and consistency of CLI output for list, show, and default get commands.