### PR TITLE
Add cache cleanup functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,7 @@ dependencies = [
  "console",
  "dirs",
  "env_logger",
+ "filetime",
  "flate2",
  "futures-util",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 tar = "0.4.44"
 tempfile = "3.20"
+filetime = "0.2"
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = { version = "0.1.41", features = ["log"] }
 whoami = "1.5.2"

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use clap::Args;
+
+use crate::handle_commands::handle_cmd;
+
+use super::ComponentCommands;
+
+/// Remove old release archives from the cache directory.
+#[derive(Args, Debug)]
+pub struct Command {
+    /// Days to keep files in cache
+    #[clap(long, short = 'd', default_value = "30")]
+    days: u32,
+
+    /// Remove all cache files
+    #[clap(long, conflicts_with = "days")]
+    all: bool,
+
+    /// Show what would be removed without actually removing anything
+    #[clap(long, short = 'n')]
+    dry_run: bool,
+}
+
+impl Command {
+    pub async fn exec(&self, github_token: &Option<String>) -> Result<()> {
+        handle_cmd(
+            ComponentCommands::Cleanup {
+                all: self.all,
+                days: self.days,
+                dry_run: self.dry_run,
+            },
+            github_token.to_owned(),
+        )
+        .await
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod self_;
 mod show;
 mod update;
 mod which;
+mod cleanup;
 
 use anyhow::{anyhow, bail, Result};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -40,6 +41,7 @@ pub enum Commands {
     Show(show::Command),
     Update(update::Command),
     Which(which::Command),
+    Cleanup(cleanup::Command),
 }
 
 impl Command {
@@ -53,6 +55,7 @@ impl Command {
             Commands::Show(cmd) => cmd.exec(),
             Commands::Update(cmd) => cmd.exec(&self.github_token).await,
             Commands::Which(cmd) => cmd.exec(),
+            Commands::Cleanup(cmd) => cmd.exec(&self.github_token).await,
         }
     }
 }
@@ -91,6 +94,19 @@ pub enum ComponentCommands {
     Remove {
         #[arg(value_enum)]
         binary: BinaryName,
+    },
+    #[command(about = "Cleanup cache files")]
+    Cleanup {
+        /// Remove all cache files
+        /// If not specified, only cache files older than `days` will be removed
+        #[arg(long, conflicts_with = "days")]
+        all: bool,
+        /// Days to keep files in cache (default: 30)
+        #[arg(long, short = 'd', default_value = "30")]
+        days: u32,
+        /// Show what would be removed without actually removing anything
+        #[arg(long, short = 'n')]
+        dry_run: bool,
     },
 }
 

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -37,6 +37,7 @@ impl ComponentManager {
                     .await
             }
             ComponentCommands::Remove { binary } => self.remove_component(binary).await,
+            ComponentCommands::Cleanup { all, days, dry_run } => self.handle_cleanup(all, days, dry_run).await
         }
     }
 
@@ -73,5 +74,9 @@ impl ComponentManager {
     /// Remove a component
     async fn remove_component(&self, binary: BinaryName) -> Result<()> {
         remove::remove_component(binary).await
+    }
+    /// Handle cleanup operations
+    async fn handle_cleanup(&self, all: bool, days: u32, dry_run: bool) -> Result<()> {
+        crate::handlers::cleanup::handle_cleanup(all, days, dry_run).await
     }
 }

--- a/src/handlers/cleanup.rs
+++ b/src/handlers/cleanup.rs
@@ -1,0 +1,151 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+
+use crate::paths::release_archive_dir;
+
+/// Handles the `cleanup` command
+pub async fn handle_cleanup(all: bool, days: u32, dry_run: bool) -> Result<()> {
+    let release_archive_dir = release_archive_dir();
+    println!(
+        "Release archives directory: {}",
+        release_archive_dir.display()
+    );
+
+    if !release_archive_dir.exists() {
+        println!("Release archives directory does not exist, nothing to clean up.");
+        return Ok(());
+    }
+
+    // Calculate total size before cleanup
+    let total_size_before = calculate_dir_size(&release_archive_dir)?;
+    println!(
+        "Current cache size: {}",
+        format_file_size(total_size_before)
+    );
+
+    if all {
+        if dry_run {
+            println!("Would remove all release archives in cache directory (dry run)");
+        } else {
+            println!("Removing all release archives in cache directory...");
+            if release_archive_dir.exists() {
+                fs::remove_dir_all(&release_archive_dir)?;
+                fs::create_dir_all(&release_archive_dir)?;
+            }
+            println!("{}", "Cache cleared successfully.");
+        }
+        return Ok(());
+    }
+
+    // Calculate cutoff duration
+    let cutoff_duration = Duration::from_secs(60 * 60 * 24 * days as u64); // days to seconds
+    let mut cleaned_size = 0;
+    let mut files_removed = 0;
+
+    println!("Removing release archives older than {} days...", days);
+
+    // Process release_archive_dir
+    if release_archive_dir.exists() {
+        let entries = fs::read_dir(&release_archive_dir)?;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                if let Ok(metadata) = fs::metadata(&path) {
+                    if let Ok(modified_time) = metadata.modified() {
+                        if let Ok(age) = SystemTime::now().duration_since(modified_time) {
+                            // Convert to days for display
+                            let days_old = age.as_secs() / (60 * 60 * 24);
+
+                            if age > cutoff_duration {
+                                let file_size = metadata.len();
+                                cleaned_size += file_size;
+                                files_removed += 1;
+
+                                if dry_run {
+                                    println!(
+                                        "Would remove: {} ({} days old, {})",
+                                        path.display(),
+                                        days_old,
+                                        format_file_size(file_size)
+                                    );
+                                } else {
+                                    println!(
+                                        "Removing: {} ({} days old, {})",
+                                        path.display(),
+                                        days_old,
+                                        format_file_size(file_size)
+                                    );
+                                    fs::remove_file(path)?;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Report results
+    if dry_run {
+        println!(
+            "Would remove {} files totaling {} (dry run)",
+            files_removed,
+            format_file_size(cleaned_size)
+        );
+    } else {
+        println!(
+            "{} {} files removed, {} freed",
+            "Cleanup complete.",
+            files_removed,
+            format_file_size(cleaned_size)
+        );
+
+        let total_size_after = calculate_dir_size(&release_archive_dir)?;
+        println!("New cache size: {}", format_file_size(total_size_after));
+    }
+
+    Ok(())
+}
+
+fn calculate_dir_size(dir: &PathBuf) -> Result<u64> {
+    let mut total_size = 0;
+    if dir.exists() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                total_size += fs::metadata(&path)?.len();
+            } else if path.is_dir() {
+                total_size += calculate_dir_size(&path)?;
+            }
+        }
+    }
+    Ok(total_size)
+}
+
+/// Format file size in human readable format
+fn format_file_size(size: u64) -> String {
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+
+    if size == 0 {
+        return "0 B".to_string();
+    }
+
+    let base = 1024_f64;
+    let exponent = (size as f64).log(base).floor() as usize;
+    let value = size as f64 / base.powi(exponent as i32);
+
+    let unit = UNITS[exponent.min(UNITS.len() - 1)];
+
+    if value < 10.0 {
+        format!("{:.2} {}", value, unit)
+    } else if value < 100.0 {
+        format!("{:.1} {}", value, unit)
+    } else {
+        format!("{:.0} {}", value, unit)
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -28,6 +28,7 @@ pub mod show;
 pub mod update;
 pub mod version;
 pub mod which;
+pub mod cleanup;
 
 pub const RELEASES_ARCHIVES_FOLDER: &str = "releases";
 

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -4,7 +4,12 @@
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use std::fs;
+    use std::time::{Duration, SystemTime};
     use suiup::commands::{parse_component_with_version, BinaryName, CommandMetadata};
+    use suiup::handlers::cleanup::handle_cleanup;
+    use suiup::paths;
+    use tempfile::TempDir;
 
     #[test]
     fn test_parse_component_with_version() -> Result<(), anyhow::Error> {
@@ -55,5 +60,104 @@ mod tests {
         assert_eq!(BinaryName::Sui.to_string(), "sui");
         assert_eq!(BinaryName::Mvr.to_string(), "mvr");
         assert_eq!(BinaryName::Walrus.to_string(), "walrus");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_empty_directory() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+
+        // Test cleanup on empty directory
+        let result = handle_cleanup(false, 30, true).await;
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_dry_run() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let cache_dir = temp_dir.path().join("suiup").join("release_archives");
+        fs::create_dir_all(&cache_dir)?;
+
+        // Create test files with different ages
+        let old_file = cache_dir.join("old_file.zip");
+        let new_file = cache_dir.join("new_file.zip");
+
+        fs::write(&old_file, b"old content")?;
+        fs::write(&new_file, b"new content")?;
+
+        // Make old file appear old by setting modified time
+        let old_time = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 40); // 40 days ago
+        filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time))?;
+
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+
+        // Dry run should not remove files
+        let result = handle_cleanup(false, 30, true).await;
+        assert!(result.is_ok());
+        assert!(old_file.exists());
+        assert!(new_file.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_remove_old_files() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        // Set up environment variable for cache directory
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        // Create cache directory
+        let cache_dir = paths::release_archive_dir();
+        fs::create_dir_all(&cache_dir)?;
+
+        // Create test files
+        let old_file = cache_dir.join("old_file.zip");
+        let new_file = cache_dir.join("new_file.zip");
+
+        fs::write(&old_file, b"old content")?;
+        fs::write(&new_file, b"new content")?;
+
+        // Make old file appear old
+        let old_time = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 40); // 40 days ago
+        filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time))?;
+
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+
+        // Actual cleanup should remove old file but keep new file
+        let result = handle_cleanup(false, 30, false).await;
+        assert!(result.is_ok());
+        assert!(!old_file.exists());
+        assert!(new_file.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_remove_all() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        // Set up environment variable for cache directory
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        // Create cache directory
+        let cache_dir = paths::release_archive_dir();
+        fs::create_dir_all(&cache_dir)?;
+
+        // Create test files
+        let file1 = cache_dir.join("file1.zip");
+        let file2 = cache_dir.join("file2.zip");
+
+        fs::write(&file1, b"content1")?;
+        fs::write(&file2, b"content2")?;
+
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+
+        // Remove all should clear everything
+        let result = handle_cleanup(true, 30, false).await;
+        assert!(result.is_ok());
+        assert!(!file1.exists());
+        assert!(!file2.exists());
+        assert!(cache_dir.exists()); // Directory should still exist
+
+        Ok(())
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,6 +9,8 @@ mod tests {
     use anyhow::Result;
     use assert_cmd::Command;
     use predicates::prelude::*;
+    use std::fs;
+    use std::time::{Duration, SystemTime};
     use suiup::paths::installed_binaries_file;
 
     #[cfg(not(windows))]
@@ -359,6 +361,169 @@ mod tests {
         cmd.assert()
             .success()
             .stdout(predicate::str::contains("1.18.2"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_command_help() -> Result<()> {
+        let test_env = TestEnv::new()?;
+
+        let mut cmd = suiup_command(vec!["cleanup", "--help"], &test_env);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("Usage: suiup cleanup"))
+            .stdout(predicate::str::contains("--all"))
+            .stdout(predicate::str::contains("--days"))
+            .stdout(predicate::str::contains("--dry-run"))
+            .stdout(predicate::str::contains("Remove all cache files"))
+            .stdout(predicate::str::contains("Days to keep files in cache"));
+
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_cleanup_dry_run_workflow() -> Result<()> {
+        let test_env = TestEnv::new()?;
+        test_env.initialize_paths()?;
+        test_env.copy_testnet_releases_to_cache()?;
+
+        let cache_dir = test_env.cache_dir.join("suiup").join("releases");
+
+        fs::create_dir_all(&cache_dir)?;
+
+        let old_file = cache_dir.join("old_release.zip");
+        fs::write(&old_file, b"old release content")?;
+
+        // Make the file appear old
+        let old_time = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 40); // 40 days ago
+        filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time))?;
+
+        // Run dry run cleanup
+        let mut cmd = suiup_command(vec!["cleanup", "--dry-run"], &test_env);
+        cmd.assert().success().stdout(predicate::str::contains(
+            "Removing release archives older than 30 days",
+        ));
+
+        // Verify file still exists after dry run
+        assert!(old_file.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_with_days_filter() -> Result<()> {
+        let test_env = TestEnv::new()?;
+        test_env.initialize_paths()?;
+        test_env.copy_testnet_releases_to_cache()?;
+
+        let cache_dir = test_env.cache_dir.join("suiup").join("releases");
+
+        fs::create_dir_all(&cache_dir)?;
+
+        // Create files with different ages
+        let old_file = cache_dir.join("old_file.zip");
+        let recent_file = cache_dir.join("recent_file.zip");
+
+        fs::write(&old_file, b"old content")?;
+        fs::write(&recent_file, b"recent content")?;
+
+        // Make old file 40 days old
+        let old_time = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 40);
+        filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time))?;
+
+        // Run cleanup with 30 days filter
+        let mut cmd = suiup_command(vec!["cleanup", "--days", "30"], &test_env);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Removing release archives older than 30 days",
+            ))
+            .stdout(predicate::str::contains("Cleanup complete"));
+
+        // Old file should be removed, recent file should remain
+        assert!(!old_file.exists());
+        assert!(recent_file.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_all_files() -> Result<()> {
+        let test_env = TestEnv::new()?;
+        test_env.initialize_paths()?;
+        test_env.copy_testnet_releases_to_cache()?;
+
+        let cache_dir = test_env.cache_dir.join("suiup").join("releases");
+
+        fs::create_dir_all(&cache_dir)?;
+
+        // Create additional test files
+        let file1 = cache_dir.join("test1.zip");
+        let file2 = cache_dir.join("test2.zip");
+
+        fs::write(&file1, b"test content 1")?;
+        fs::write(&file2, b"test content 2")?;
+
+        // Verify files exist before cleanup
+        assert!(file1.exists());
+        assert!(file2.exists());
+
+        // Run cleanup with --all flag
+        let mut cmd = suiup_command(vec!["cleanup", "--all"], &test_env);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("Removing all release archives"))
+            .stdout(predicate::str::contains("Cache cleared successfully")); 
+
+        // All files should be removed
+        assert!(!file1.exists());
+        assert!(!file2.exists());
+
+        // But directory should still exist
+        assert!(cache_dir.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_after_install_workflow() -> Result<()> {
+        let test_env = TestEnv::new()?;
+        test_env.initialize_paths()?;
+        test_env.copy_testnet_releases_to_cache()?;
+
+        // Install a component first to create cache files
+        let mut cmd = suiup_command(vec!["install", "sui@testnet-1.39.3", "-y"], &test_env);
+        cmd.assert().success();
+
+        let cache_dir = test_env.cache_dir.join("suiup").join("releases");
+
+        fs::create_dir_all(&cache_dir)?;
+
+        let old_file = cache_dir.join("old_archive.zip");
+        fs::write(&old_file, b"old archive")?;
+        let old_time = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 40);
+        filetime::set_file_mtime(&old_file, filetime::FileTime::from_system_time(old_time))?;
+
+        // Run cleanup
+        let mut cmd = suiup_command(vec!["cleanup", "--days", "30"], &test_env);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("Cleanup complete"));
+
+        // Verify old file is removed
+        assert!(!old_file.exists());
+
+        // Verify installed binary still works
+        #[cfg(windows)]
+        let default_sui_binary = test_env.bin_dir.join("sui.exe");
+        #[cfg(not(windows))]
+        let default_sui_binary = test_env.bin_dir.join("sui");
+
+        let mut cmd = Command::new(default_sui_binary);
+        cmd.arg("--version");
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("1.39.3"));
 
         Ok(())
     }


### PR DESCRIPTION
# Cache Cleanup Functionality

## Description
This PR adds a new `cleanup` command to address the known issue mentioned in the README: "There is no cleanup functionality, so the cache might grow bigger."

## Features
- Add a new `cleanup` command to clean release archive cache files
- Support cleaning by age (default: 30 days)
- Support cleaning all cache files with `--all` flag
- Dry run mode with `--dry-run` flag
- Detailed reporting of cleaned space and remaining cache size

## Testing
Added unit tests that verify:
- Cleanup of files older than specified days
- Full cache cleanup with `--all` flag
- Dry run mode functionality

## Usage
```bash
# Clean files older than 30 days (default)
suiup cleanup

# Clean files older than 7 days
suiup cleanup --days 7

# Clean all cache files
suiup cleanup --all

# Show what would be removed without actually removing
suiup cleanup --dry-run