### PR TITLE
Add cache cleanup functionality and improve error handling

### DIFF
--- a/src/commands/default/get.rs
+++ b/src/commands/default/get.rs
@@ -18,8 +18,8 @@ use crate::commands::print_table;
 pub struct Command;
 
 impl Command {
-    pub fn exec(&self) -> Result<()> {
-        let default = std::fs::read_to_string(default_file_path()?)?;
+    pub async fn exec(&self) -> Result<()> {
+        let default = tokio::fs::read_to_string(default_file_path().await?).await?;
         let default: BTreeMap<String, (String, Version, bool)> = serde_json::from_str(&default)?;
         let binaries = Binaries::from(default);
 

--- a/src/commands/default/mod.rs
+++ b/src/commands/default/mod.rs
@@ -23,9 +23,10 @@ enum Commands {
 impl Command {
     /// Handles the default commands
     pub fn exec(&self) -> Result<()> {
+        let rt = tokio::runtime::Runtime::new().unwrap();
         match &self.command {
-            Commands::Get(cmd) => cmd.exec(),
-            Commands::Set(cmd) => cmd.exec(),
+            Commands::Get(cmd) => rt.block_on(cmd.exec()),
+            Commands::Set(cmd) => rt.block_on(cmd.exec()),
         }
     }
 }

--- a/src/component/install.rs
+++ b/src/component/install.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};
-use std::fs::create_dir_all;
+use tokio::fs::create_dir_all;
 
 use crate::commands::BinaryName;
 use crate::handlers::install::{install_from_nightly, install_from_release, install_mvr};
@@ -21,10 +21,10 @@ pub async fn install_component(
 ) -> Result<()> {
     // Ensure installation directories exist
     let default_bin_dir = get_default_bin_dir();
-    create_dir_all(&default_bin_dir)?;
+    create_dir_all(&default_bin_dir).await?;
 
     let installed_bins_dir = binaries_dir();
-    create_dir_all(&installed_bins_dir)?;
+    create_dir_all(&installed_bins_dir).await?;
 
     if name != BinaryName::Sui && debug && nightly.is_none() {
         return Err(anyhow!("Debug flag is only available for the `sui` binary"));
@@ -38,7 +38,7 @@ pub async fn install_component(
 
     match (&name, &nightly) {
         (BinaryName::Walrus, nightly) => {
-            create_dir_all(installed_bins_dir.join(network.clone()))?;
+            create_dir_all(installed_bins_dir.join(network.clone())).await?;
             if let Some(branch) = nightly {
                 install_from_nightly(&name, branch, debug, yes).await?;
             } else {
@@ -55,7 +55,7 @@ pub async fn install_component(
             }
         }
         (BinaryName::WalrusSites, nightly) => {
-            create_dir_all(installed_bins_dir.join("mainnet"))?;
+            create_dir_all(installed_bins_dir.join("mainnet")).await?;
             if let Some(branch) = nightly {
                 install_from_nightly(&name, branch, debug, yes).await?;
             } else {
@@ -73,7 +73,7 @@ pub async fn install_component(
         }
 
         (BinaryName::Mvr, nightly) => {
-            create_dir_all(installed_bins_dir.join("standalone"))?;
+            create_dir_all(installed_bins_dir.join("standalone")).await?;
             if let Some(branch) = nightly {
                 install_from_nightly(&name, branch, debug, yes).await?;
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use suiup::paths::initialize;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
-    initialize()?;
+    initialize().await?;
 
     let cmd = Command::parse();
     if let Err(err) = cmd.exec().await {


### PR DESCRIPTION
This PR includes several improvements:

## Summary
- Add cache cleanup functionality (#69)
- Fix build failed issue (#74)  
- Improve error message for when a release does not exist (#63, #66)
- Add support to switch between different nightly versions for the same binary (#68)
- Add usage examples for cleanup command (#76)

## Changes
- Enhanced error handling across multiple modules
- Improved path handling and component management
- Added comprehensive cleanup features
- Updated CLI output formatting

## Testing
Please verify that:
- [ ] Cleanup functionality works as expected
- [ ] Error messages are helpful for users
- [ ] Build passes successfully
- [ ] Nightly version switching works correctly