### PR TITLE
fix: correct binary path handling for Windows to prevent non-existent paths

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -397,7 +397,7 @@ pub fn installed_binaries_grouped_by_network(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_binary_path, check_if_binaries_exist};
+    use super::check_if_binaries_exist;
     use crate::paths::binaries_dir;
     use std::fs::{self, File};
     use std::io::Write;


### PR DESCRIPTION
Cherry-picked from PR #105 by @Akagi201

This fix corrects binary path handling for Windows to prevent non-existent paths.

Original PR: #105
Original Author: @Akagi201