### PR TITLE
[bug] sometimes the OS is ubuntu, which was not explicitly supported

### DIFF
--- a/src/handlers/self_.rs
+++ b/src/handlers/self_.rs
@@ -218,6 +218,7 @@ fn find_archive_name() -> Result<String> {
     let (os, arch) = detect_os_arch()?;
 
     let os = match os.as_str() {
+        "ubuntu" => "Linux-musl",
         "linux" => "Linux-musl",
         "windows" => "Windows",
         "macos" => "macOS",


### PR DESCRIPTION
#148 shows that sometimes the OS is ubuntu, which was not explicitly supported.