### PR TITLE
add walrus-deploy binary

### DIFF
--- a/binaries/walrus-deploy.toml
+++ b/binaries/walrus-deploy.toml
@@ -1,0 +1,12 @@
+name = "walrus-deploy"
+description = "Walrus deployment CLI"
+repository = "MystenLabs/walrus"
+main_branch = "main"
+installation_type = "archive"
+network_based = true
+supported_networks = ["testnet", "devnet", "mainnet"]
+default_network = "testnet"
+supports_debug = false
+cargo_package = "walrus-service"
+nightly_toolchain = ""
+shared_repo_binary = true


### PR DESCRIPTION
## Summary

Adds \`binaries/walrus-deploy.toml\` so \`suiup install walrus-deploy\` works on every supported platform.

The walrus-deploy binary lives inside the existing per-platform release tarballs that MystenLabs/walrus publishes — it was added to the \`release_binaries\` set upstream in MystenLabs/walrus#3349 (landed). suiup just needs the registry entry to know about it; \`build.rs\` auto-discovers everything in \`binaries/\`.

## Why \`shared_repo_binary = true\`

Mirrors the \`sui-node.toml\` / \`move-analyzer.toml\` pattern: the binary name doesn't match the archive identifier (archive is \`walrus-<network>-v<X.Y.Z>-<os>-<arch>.tgz\`, binary inside is \`walrus-deploy\`), so suiup needs to look up the archive by repository and then extract by filename rather than by archive name.

| Binary | Archive identifier | Match | shared_repo_binary |
|---|---|---|---|
| \`walrus\` | \`walrus-*.tgz\` | ✅ | \`false\` |
| \`walrus-deploy\` (new) | \`walrus-*.tgz\` | ❌ | **\`true\`** |
| \`sui\` | \`sui-*.tgz\` | ✅ | \`false\` |
| \`sui-node\` | \`sui-*.tgz\` | ❌ | \`true\` |

## Local verification

\`\`\`
$ cargo run --quiet -- list
 Binary           Description
══════════════════════════════════════
 ...
 walrus           Walrus CLI
 walrus-deploy    Walrus deployment CLI
 ...
\`\`\`

## Backwards compatibility

Net new file. No changes to any other binary's config or to suiup core. \`build.rs\` already auto-discovers \`binaries/*.toml\` at build time and embeds them, so no source code edits are required.

## Test plan

- [ ] \`cargo build\` (verifies the toml parses + embeds cleanly)
- [ ] \`suiup list\` includes \`walrus-deploy\`
- [ ] After v1.49 walrus release ships: \`suiup install walrus-deploy\` extracts the right binary on linux x86_64 / linux arm64 / macos x86_64 / macos arm64 / windows x86_64
- [ ] \`suiup install walrus-deploy@mainnet-1.49.0\` resolves a specific version

## Sequencing

This PR can land any time, but \`suiup install walrus-deploy\` only succeeds against walrus releases v1.49.0+. Any earlier tag's tarballs don't contain walrus-deploy.

## Reported by

Michael Hayes ([Slack thread](https://mysten-labs.slack.com/archives/C079UUZQSM6/p1778019500764249)) — building a local-dev-stack tool, currently stuck rebuilding walrus from source for ~15-20 min on every cold start because walrus-deploy isn't a release artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)